### PR TITLE
feat: add validation pipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,12 +143,9 @@ export class AppModule {}
 import { ZodValidationPipe } from '@wahyubucil/nestjs-zod-openapi'
 
 // controller-level
-@UsePipes(ZodValidationPipe)
-class CatsController {}
-
 class CatsController {
   // route-level
-  @UsePipes(ZodValidationPipe)
+  @UsePipes(new ZodValidationPipe(CatDto))
   async create() {}
 }
 ```
@@ -270,6 +267,7 @@ export class CatsController {
     description: 'The record has been successfully created.',
     type: CreateCatResponseDto,
   })
+  @UsePipes(new ZodValidationPipe(CatDto))
   async create(@Body() createCatDto: CatDto) {
     return CreateCatResponseDto.zodSchema.parse({
       success: true,
@@ -282,6 +280,7 @@ export class CatsController {
   @ApiOkResponse({
     type: UpdateCatDto,
   })
+  @UsePipes(new ZodValidationPipe(UpdateCatDto))
   async update(@Body() updateCatDto: UpdateCatDto) {
     return UpdateCatResponseDto.zodSchema.parse({
       success: true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,10 @@
 export * from './patch-nest-swagger'
+export { ZodValidateError, ZodValidationPipe } from './zodValidation'
 export {
   CompatibleZodInfer,
   CompatibleZodType,
   createZodDto,
   MergeZodSchemaOutput,
   ZodDtoStatic,
-  ZodValidationPipe,
   ZodValidationPipeOptions,
 } from '@anatine/zod-nestjs'

--- a/src/zodValidation.ts
+++ b/src/zodValidation.ts
@@ -1,0 +1,21 @@
+import { ForbiddenException, PipeTransform } from '@nestjs/common'
+import { ZodError } from 'zod'
+import { ZodDtoStatic } from '.'
+
+export class ZodValidationPipe implements PipeTransform {
+  constructor(private schema: ZodDtoStatic) {}
+
+  transform(value: unknown) {
+    try {
+      return this.schema.zodSchema.parse(value)
+    } catch (error: ZodError | unknown) {
+      throw new ZodValidateError(error as ZodError)
+    }
+  }
+}
+
+export class ZodValidateError extends ForbiddenException {
+  constructor(error: ZodError) {
+    super({ message: error.name, error: error.errors })
+  }
+}


### PR DESCRIPTION
add validation pipe that can be used with @UsePipes & passing in the object to be validated.
`@UsePipes(new ZodValidationPipe(CatDto))`
throws custom  ForbiddenException (`ZodValidateError`). ideally, it could be modified to return the whole error object.
